### PR TITLE
Speeds up hot reload

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require("path");
 
 module.exports = {
-    mode: "none",
+    mode: "development",
     entry: "./src/App.fsproj",
     devServer: {
         contentBase: path.join(__dirname, "./dist")


### PR DESCRIPTION
See the whole drama documented [here](https://github.com/fable-compiler/Fable/issues/2079) or [here](https://twitter.com/asp_net/status/1270357334586535936). I worked through the Elmish Book and was wondering why changes made to the F# part were applied so slowly. 

I could eventually track it down to that setting in the webpack config. Note: I do not know if this might have any unintended side effects. The only thing I made sure is the performance comparison. With mode set to `none`, it seems to do a full compilation every time. With mode set to `development`, it is much, much faster. That's also the default value that ships with the Fable.Template.