### PR TITLE
Add information about .NET 7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requirements
 > 
 > Example:
 > 
-> ```bash
+> ```json
 > {
 >   "sdk": {
 >     "version": "6.0.0",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ Requirements
  - [.NET Core](https://www.microsoft.com/net/download) 2.2+
  - [Node.js](https://nodejs.org/en/) 10.0+
 
+> **Fable 3 only supports up to .NET 6.**
+>
+> If you are using .NET 7 or later you will need to add a `global.json` file to your project and install the [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
+> 
+> Example:
+> 
+> ```bash
+> {
+>   "sdk": {
+>     "version": "6.0.0",
+>     "rollForward": "latestMinor"
+>   }
+> }
+> ```
+
 ### Installation
 
 To compile the project, run the following commands


### PR DESCRIPTION
I ran into some issues getting this running on a newer machine. Decided to just add information to the `README.md` instead of adding the file and setting the `TargetFramework` to maximize the backwards compatibility. However; if you want to go the extra step add the file and also update the `App.fsproj` file to the following (28-08-2023):

```code
<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
        <TargetFramework>net6.0</TargetFramework>
    </PropertyGroup>
    <ItemGroup>
        <Compile Include="App.fs" />
    </ItemGroup>
    <ItemGroup>
      <PackageReference Include="Fable.Browser.Dom" Version="2.14.0" />
    </ItemGroup>
</Project>
```

The error you get if not doing any of this is `FSharp.Compiler.ErrorLogger+UnresolvedPathReferenceNoRange` which might be good to add here for visibility to others.